### PR TITLE
Move XC modaility from strict is xray

### DIFF
--- a/rap_sitkcore/is_dicom_xray.py
+++ b/rap_sitkcore/is_dicom_xray.py
@@ -2,8 +2,16 @@ import pydicom
 from pydicom.errors import InvalidDicomError
 from pathlib import Path
 
-_strict_modalities = ("CR", "XC", "RG", "XA", "DX")
-_acceptable_modalities = _strict_modalities + ("HC",)
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+_strict_modalities = ("CR", "RG", "XA", "DX")
+_acceptable_modalities = _strict_modalities + (
+    "HC",
+    "XC",
+)
 
 
 def is_dicom_xray(filename: Path, strict: bool = False) -> bool:
@@ -21,6 +29,7 @@ def is_dicom_xray(filename: Path, strict: bool = False) -> bool:
 
     try:
         with pydicom.dcmread(filename, specific_tags=["Modality"]) as ds:
+            _logger.debug(f'"{str(filename)}" has "{ds.Modality}" modality.')
             if strict:
                 return ds.Modality in _strict_modalities
             return ds.Modality in _acceptable_modalities

--- a/test/unit/test_is_dicom_xray.py
+++ b/test/unit/test_is_dicom_xray.py
@@ -58,3 +58,28 @@ def test_is_dicom_xray3():
                 fout.write(os.urandom(1024 * 10))
 
             assert not rap_sitkcore.is_dicom_xray(fpath)
+
+
+@pytest.mark.parametrize(
+    ("test_file", "is_xray"),
+    [
+        ("1.3.6.1.4.1.25403.163683357445804.11044.20131119114627.12.dcm", True),
+        ("1.3.6.1.4.1.25403.158515237678667.5060.20130807021253.18.dcm", True),
+        ("1.2.840.114062.2.192.168.196.13.2015.11.4.13.11.45.13871156.dcm", True),
+        ("2.25.288816364564751018524666516362407260298.dcm", False),  # "XC" modality
+        ("2.25.240995260530147929836761273823046959883.dcm", True),
+        ("2.25.226263219114459199164755074787420926696.dcm", True),
+        ("2.25.40537326380965754670062689705190363681.dcm", False),  # "XC" modality
+        ("2.25.326714092011492114153708980185182745084.dcm", False),  # "XC" modality
+        ("2.25.5871713374023139953558641168991505875.dcm", True),
+        ("n10.dcm", False),  # "OT" modality
+        ("n11.dcm", False),  # "OT" modality
+        ("n12.dcm", False),  # "OT" modality
+    ],
+)
+def test_is_dicom_xray4(test_file, is_xray):
+    """Testing with strict option"""
+
+    filename = data_paths[test_file]
+
+    assert rap_sitkcore.is_dicom_xray(Path(filename), strict=True) == is_xray


### PR DESCRIPTION
The XC modality is External-camera Photography is ussually an
idication that the DICOM was aquired with a derived process and may
not be an x-ray.