### PR TITLE
Add resize_and_scale_uint8 method

### DIFF
--- a/rap_sitkcore/__init__.py
+++ b/rap_sitkcore/__init__.py
@@ -1,5 +1,6 @@
 from .read_dcm import read_dcm
 from .is_dicom_xray import is_dicom_xray
+from .resize import resize_and_scale_uint8
 
 try:
     from importlib.metadata import version, PackageNotFoundError
@@ -19,4 +20,4 @@ except PackageNotFoundError:
 
 __author__ = ["Bradley Lowekamp"]
 
-__all__ = ["read_dcm", "is_dicom_xray"]
+__all__ = ["read_dcm", "is_dicom_xray", "resize_and_scale_uint8"]

--- a/rap_sitkcore/resize.py
+++ b/rap_sitkcore/resize.py
@@ -1,0 +1,37 @@
+import SimpleITK as sitk
+from typing import List
+
+
+def resize_and_scale_uint8(image: sitk.Image, new_size: List[int]) -> sitk.Image:
+    """
+    Resize the given image to the given size, with isotropic pixel spacing
+    and scale the intensities to [0,255].
+
+    Resizing retains the original aspect ratio, with the original image centered
+    in the new image. Zero padding is added outside the original image extent.
+
+    :param image: A SimpleITK image.
+    :param new_size: List of ints specifying the new image size.
+    :return: a 2D SimpleITK image with desired size and a pixel type of sitkUInt8
+    """
+
+    new_spacing = [
+        ((osz - 1) * ospc) / (nsz - 1) for ospc, osz, nsz in zip(image.GetSpacing(), image.GetSize(), new_size)
+    ]
+    new_spacing = [max(new_spacing)] * image.GetDimension()
+    center = image.TransformContinuousIndexToPhysicalPoint([sz / 2.0 for sz in image.GetSize()])
+    new_origin = [c - c_index * nspc for c, c_index, nspc in zip(center, [sz / 2.0 for sz in new_size], new_spacing)]
+    final_image = sitk.Resample(image, size=new_size, outputOrigin=new_origin, outputSpacing=new_spacing)
+
+    # Rescale intensities if scalar image with pixel type that isn't sitkUInt8.
+    if final_image.GetPixelID() == sitk.sitkUInt8:
+        pass
+    elif final_image.GetNumberOfComponentsPerPixel() == 1:
+        final_image = sitk.Cast(sitk.RescaleIntensity(final_image), sitk.sitkUInt8)
+    else:
+        raise ValueError(
+            "Intensity scaling is not supported for image with "
+            f"{final_image.GetNumberOfComponentsPerPixel()} components and "
+            f'pixel type of "{image.GetPixelIDTypeAsString()}"'
+        )
+    return final_image

--- a/test/unit/test_resize.py
+++ b/test/unit/test_resize.py
@@ -1,0 +1,26 @@
+from rap_sitkcore import read_dcm, resize_and_scale_uint8
+import pytest
+from pathlib import Path
+from .. import data_paths
+import SimpleITK as sitk
+
+
+@pytest.mark.parametrize(
+    "file_name,thumbnail_size,md5_hash",
+    [
+        ("non_square_color.dcm", (256, 256), "7fb3fa09f1e5ac1c7376334ebc6f07c2"),
+        ("non_square_uint16.dcm", (256, 256), "3f9ef4f27775ecab75586a319ae4bfe5"),
+        ("square_uint8.dcm", (256, 256), "e8358046f74f0977f2e55df97bab0318"),
+    ],
+)
+def test_dcm_thumbnail(file_name, thumbnail_size, md5_hash):
+
+    filename = data_paths[file_name]
+    img = read_dcm(Path(filename))
+
+    thumbnail_img = resize_and_scale_uint8(img, thumbnail_size)
+
+    assert thumbnail_img.GetSize() == thumbnail_size
+    assert sitk.Hash(thumbnail_img, function=sitk.HashImageFilter.MD5) == md5_hash
+    assert thumbnail_img.GetNumberOfComponentsPerPixel() == 1
+    assert thumbnail_img.GetPixelID() == sitk.sitkUInt8


### PR DESCRIPTION
This method has been copied from the tbp_image_refresh project along
with testing. Additionally, an exception will not be thrown for
multicomponent (RGB) images that are not scaled.