### PR TITLE
Move pylibjpeg dependecies as extra

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-        pip install -e .
+        pip install -e .[pylibjpeg]
     - name: Test with pytest
       run: |
         python -m pytest

--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,9 @@ Then running::
 
 Then the `rap_sitkcore` package can be installed if specified in another projects requirements.txt.
 
+For pydicom to support more encodings additional pylibjpeg packages can be install. These dependencies are specified as
+extra requirements in the setup.py. Specifying the package a "rap_sitkcore[pylibjpeg]" will install the extra packages.
+
 Github Releases
 ^^^^^^^^^^^^^^^
 

--- a/requirements-pylibjpeg.txt
+++ b/requirements-pylibjpeg.txt
@@ -1,0 +1,7 @@
+# optional/extra packages for pydicom support for additional encodings
+pylibjpeg
+pylibjpeg-rle
+
+# earlier versions did not correctly represent the version dependency on numpy
+pylibjpeg-libjpeg>=1.3.1
+pylibjpeg-openjpeg>=1.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,3 @@ requests
 
 # additional packages for pydicom to expand supported files
 pillow
-pylibjpeg
-pylibjpeg-rle
-# earlier versions did not correctly represent the version dependecy on numpy
-pylibjpeg-libjpeg>=1.3.1
-pylibjpeg-openjpeg>=1.2.1
-

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,16 @@ from setuptools import setup
 with open("README.rst", "r") as fp:
     long_description = fp.read()
 
-with open("requirements.txt", "r") as fp:
-    requirements = list(filter(bool, (line.strip() for line in fp)))
+
+def parse_requirements_file(filename):
+    with open(filename, "r", encoding="utf-8") as fp:
+        req = [line.strip() for line in fp.readlines() if line]
+    return req
+
+
+requirements = parse_requirements_file("requirements.txt")
+
+requirements_pylibjpeg = parse_requirements_file("requirements-pylibjpeg.txt")
 
 setup(
     name="rap_sitkcore",
@@ -37,6 +45,7 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
     ],
+    extras_require={"pylibjpeg": requirements_pylibjpeg},
     python_requires=">=3.7",
     install_requires=requirements,
 )


### PR DESCRIPTION
These packages have had versioning problem and currently are not
supported, on ARM OSX. Make them an option extra installable with
 "rap_sitkCore[pylibjpeg]"